### PR TITLE
Fix oreQuarry blacklist parser

### DIFF
--- a/Lua/quarry.lua
+++ b/Lua/quarry.lua
@@ -773,7 +773,7 @@ if fs.exists(oreQuarryBlacklistName) then --Loading user-defined blacklist
   local file = fs.open(oreQuarryBlacklistName, "r")
   blacklist = {}
   for a in file:readAll():gmatch("[^,]+") do
-    blacklist[a:match("[%w_]+:%[%w_]+")] = true --Grab only the actual characters, not whitespaces
+    blacklist[a:match("[%w_]+:[%w_]+")] = true --Grab only the actual characters, not whitespaces
   end
   file:close()
 end


### PR DESCRIPTION
Fixes an error (776: table index expected, got nil) experienced when using a custom blacklist with oreQuarry